### PR TITLE
skip upload steps on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,10 @@ on:
       projects:
         required: true
         type: string
+      upload:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -197,6 +201,7 @@ jobs:
 
       - name: upload bottles
         id: upload
+        if: ${{ inputs.upload }}
         run: pantry/scripts/upload.ts
           --pkgs ${{ needs.build.outputs.built }} ${{ needs.build.outputs.built }}
           --srcs ${{ needs.build.outputs.srcs }} ${{ needs.build.outputs.srcs }}
@@ -210,6 +215,7 @@ jobs:
       #NOTE ideally we’d invalidate all at once so this is atomic
       # however GHA can’t consolidate outputs from a matrix :/
       - uses: chetan/invalidate-cloudfront-action@v2
+        if: ${{ inputs.upload }}
         env:
           PATHS: ${{ steps.upload.outputs.cf-invalidation-paths }}
           DISTRIBUTION: ${{ secrets.AWS_CF_DISTRIBUTION_ID }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,3 +15,21 @@ jobs:
           jq -sc . |
           curl https://app.tea.xyz/api/receiveWatcherProjects --fail -X PUT \
             -H "content-type: application/json" -H "authorization: bearer ${{ secrets.TEA_API_TOKEN }}" -d @-
+  get-diff:
+    runs-on: ubuntu-latest
+    outputs:
+      diff: ${{ steps.diff.outputs.diff }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: technote-space/get-diff-action@v6
+        id: diff
+        with:
+          PATTERNS: projects/**/package.yml
+  build:
+    needs: [get-diff]
+    uses: ./.github/workflows/build.yml
+    with:
+      projects: ${{ needs.get-diff.outputs.diff }}
+      upload: true
+    secrets: inherit
+    if: ${{ needs.get-diff.outputs.diff != '' }}

--- a/.github/workflows/new-version.yml
+++ b/.github/workflows/new-version.yml
@@ -13,4 +13,5 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       projects: ${{ inputs.projects }}
+      upload: true
     secrets: inherit

--- a/projects/zlib.net/package.yml
+++ b/projects/zlib.net/package.yml
@@ -22,3 +22,4 @@ test:
     test "$OUT" = "$INPUT"
   env:
     INPUT: Hello, World!
+


### PR DESCRIPTION
only runs the upload/invalidate steps if we're building a newVersion (on main) or when merging (in CD).