### PR TITLE
pass through `ld` more smartly

### DIFF
--- a/projects/deno.land/package.yml
+++ b/projects/deno.land/package.yml
@@ -37,4 +37,3 @@ build:
 
 test:
   script: deno --version
-

--- a/projects/tea.xyz/gx/cc/ld
+++ b/projects/tea.xyz/gx/cc/ld
@@ -2,6 +2,10 @@
 
 exe=$(basename "$0")
 
+if test ! -f /usr/bin/"$exe"; then
+  exe=ld
+fi
+
 if test -z "$TEA_PREFIX"
 then
   echo 'TEA_PREFIX mysteriously unset' >&2

--- a/projects/tea.xyz/gx/cc/package.yml
+++ b/projects/tea.xyz/gx/cc/package.yml
@@ -41,4 +41,3 @@ build:
 test: |
   cc --version
   ld --help
-


### PR DESCRIPTION
- [x] fixes https://github.com/teaxyz/pantry.core/actions/runs/3339438265

Builds deno.land correctly: https://github.com/teaxyz/pantry.core/commit/6284cc585c1e162247cdc4fc5d1d5bed618dac8a/checks?check_suite_id=8999639875

(leaving that whitespace change in deno.land, because a) it doesn't need two newlines, and b) deno.land 1.27.0 needs to be built anyway)