### PR TITLE
deno needs cargo to build

### DIFF
--- a/projects/deno.land/package.yml
+++ b/projects/deno.land/package.yml
@@ -31,6 +31,7 @@ build:
   dependencies:
     git-scm.org: 2       # to build tinycc
     rust-lang.org: 1
+    rust-lang.org/cargo: ^0.65
     llvm.org: '>=13'     # macOS/aarch64 requires this (FIXME only dep where needed)
     curl.se: '*'         # required to download v8 (python is another option)
     tea.xyz/gx/make: '*' # required to build the libffi parts

--- a/scripts/build/build.ts
+++ b/scripts/build/build.ts
@@ -49,7 +49,8 @@ async function __build(pkg: Package): Promise<BuildResult> {
 
   async function clean() {
     const installation = await should_clean()
-    if (installation) {
+    // If we clean deno.land, it breaks the rest of the process.
+    if (installation && installation.pkg.project !== "deno.land") {
       console.log({ cleaning: installation.path })
       for await (const [path] of installation.path.ls()) {
         // we delete contents rather than the directory itself to prevent broken vx.y symlinks


### PR DESCRIPTION
- [x] `deno.land` depends on `rust-lang.org/cargo`.
- [x] `build/build.ts` causes issues with build scripts if it cleans the deno binary it needs to work.