### PR TITLE
remove deprecated (finally removed?) `rls`

### DIFF
--- a/projects/rust-lang.org/package.yml
+++ b/projects/rust-lang.org/package.yml
@@ -13,7 +13,6 @@ provides:
   - bin/cargo-clippy
   - bin/cargo-fmt
   - bin/clippy-driver
-  - bin/rls
   - bin/rust-analyzer
   - bin/rust-gdb
   - bin/rust-gdbgui
@@ -24,7 +23,6 @@ provides:
 
 #TODO: unimplemented idea for the “options” feature
 options:
-  - rls
   - clippy
   - rustfmt
   - analysis
@@ -63,9 +61,8 @@ build:
       - --prefix={{ prefix }}
       - --enable-ninja
       - --disable-docs  # docs are online
-      - --tools=rls,clippy,rustfmt,analysis
+      - --tools=clippy,rustfmt,analysis
     tools:
-      - rls       # deprecated for rust-analyzer some time ago -- remove eventually
       - clippy
       - rustfmt
       - rust-analyzer


### PR DESCRIPTION
https://blog.rust-lang.org/2022/11/03/Rust-1.65.0.html#compatibility-notes