### PR TITLE
Relax requirement to build to /opt

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
             ;;
           esac
 
-        - run: # noop for pantry.core but needed for pantry.extra etc.
+        - run: | # noop for pantry.core but needed for pantry.extra etc.
           cp -nR \
             /opt/tea.xyz/var/pantry/scripts \
             /opt/tea.xyz/var/pantry/import-map.json \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,12 +66,12 @@ jobs:
             ;;
           esac
 
-          # noop for pantry.core but needed for pantry.extra etc.
+        - run: # noop for pantry.core but needed for pantry.extra etc.
           cp -nR \
             /opt/tea.xyz/var/pantry/scripts \
             /opt/tea.xyz/var/pantry/import-map.json \
             pantry
-          cd pantry && ln -sf ../cli/src
+        - run: cd pantry && ln -sf ../cli/src
 
       - run: pantry/scripts/sort.ts ${{ inputs.projects }}
         id: sorted

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,5 @@
 name: build
+
 on:
   workflow_call:
     inputs:
@@ -9,6 +10,9 @@ on:
         required: false
         type: boolean
         default: false
+
+env:
+  TEA_PANTRY_PATH: ${{ github.workspace }}/pantry
 
 jobs:
   build:
@@ -30,8 +34,6 @@ jobs:
       built: ${{ steps.build.outputs.pkgs }}
       srcs: ${{ steps.build.outputs.srcs }}
       pkgs: ${{ steps.sorted.outputs.pkgs }} ${{ steps.sorted.outputs.pre-install }}
-    env:
-      TEA_PANTRY_PATH: ${{ github.workspace }}/pantry
     steps:
       - name: co pantry
         uses: actions/checkout@v3
@@ -117,18 +119,18 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          path: cli
+          path: tea.xyz/var/cli
           repository: teaxyz/cli
+
+      - uses: actions/checkout@v3
+        with:
+          path: pantry
 
       - uses: teaxyz/setup@v0
         id: tea
         with:
           srcroot: tea.xyz/var/pantry
           prefix: ${{ github.workspace }}
-
-      - uses: actions/checkout@v3
-        with:
-          path: tea.xyz/var/pantry
 
       - run: |
           apt-get update
@@ -161,18 +163,18 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          path: cli
+          path: tea.xyz/var/cli
           repository: teaxyz/cli
+
+      - uses: actions/checkout@v3
+        with:
+          path: pantry
 
       - uses: teaxyz/setup@v0
         id: tea
         with:
           srcroot: tea.xyz/var/pantry
           prefix: ${{ github.workspace }}
-
-      - uses: actions/checkout@v3
-        with:
-          path: tea.xyz/var/pantry
 
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
       - run: cli/scripts/install.ts ${{ steps.sorted.outputs.pre-install }}
 
       # running out of /opt because only pantry.core has these scripts
-      - run: /opt/tea.xyz/var/scripts/build.ts ${{ steps.sorted.outputs.pkgs }}
+      - run: /opt/tea.xyz/var/pantry/scripts/build.ts ${{ steps.sorted.outputs.pkgs }}
         id: build
         env:
           # GITHUB_TOKEN doesn't have private access to teaxyz/cli.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,15 +64,6 @@ jobs:
             ;;
           esac
 
-      - run: |
-          find $GITHUB_WORKSPACE/pantry \
-            -not -type l \
-            -mindepth 1 \
-            -maxdepth 1 \
-            -print0 | \
-              xargs -0 -I{} cp -Rv {} /opt/tea.xyz/var/pantry
-          cp -a cli /opt/tea.xyz/var/
-
       - run: /opt/tea.xyz/var/pantry/scripts/sort.ts ${{ inputs.projects }}
         id: sorted
 
@@ -142,15 +133,6 @@ jobs:
           srcroot: tea.xyz/var/pantry
           prefix: ${{ github.workspace }}
 
-      - name: overlay our pantry
-        run: |
-          find pantry \
-            -not -type l \
-            -mindepth 1 \
-            -maxdepth 1 \
-            -print0 | \
-              xargs -0 -I{} cp -Rv {} tea.xyz/var/pantry
-
       - uses: actions/download-artifact@v3
         with:
           name: ${{ matrix.tag || matrix.os }}
@@ -191,15 +173,6 @@ jobs:
         with:
           srcroot: tea.xyz/var/pantry
           prefix: ${{ github.workspace }}
-
-      - name: overlay our pantry
-        run: |
-          find $GITHUB_WORKSPACE/pantry \
-            -not -type l \
-            -mindepth 1 \
-            -maxdepth 1 \
-            -print0 | \
-              xargs -0 -I{} cp -Rv {} .
 
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,8 @@ jobs:
             ;;
           esac
 
+          ln -s $GITHUB_WORKSPACE/cli /opt/tea.xyz/var/cli
+
       - run: /opt/tea.xyz/var/pantry/scripts/sort.ts ${{ inputs.projects }}
         id: sorted
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,8 +70,8 @@ jobs:
           cp -nR \
             /opt/tea.xyz/var/pantry/scripts \
             /opt/tea.xyz/var/pantry/import-map.json \
-            cli/src \
             pantry
+          ln -sf cli/src pantry/src
 
       - run: pantry/scripts/sort.ts ${{ inputs.projects }}
         id: sorted

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,10 +67,10 @@ jobs:
           esac
 
         - run: | # noop for pantry.core but needed for pantry.extra etc.
-          cp -nR \
-            /opt/tea.xyz/var/pantry/scripts \
-            /opt/tea.xyz/var/pantry/import-map.json \
-            pantry
+            cp -nR \
+              /opt/tea.xyz/var/pantry/scripts \
+              /opt/tea.xyz/var/pantry/import-map.json \
+              pantry
         - run: cd pantry && ln -sf ../cli/src
 
       - run: pantry/scripts/sort.ts ${{ inputs.projects }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
           esac
 
           # noop for pantry.core but needed for pantry.extra etc.
-          cp -R \
+          cp -nR \
             /opt/tea.xyz/var/pantry/scripts \
             /opt/tea.xyz/var/pantry/import-map.json \
             cli/src \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,8 @@ jobs:
       built: ${{ steps.build.outputs.pkgs }}
       srcs: ${{ steps.build.outputs.srcs }}
       pkgs: ${{ steps.sorted.outputs.pkgs }} ${{ steps.sorted.outputs.pre-install }}
+    env:
+      TEA_DIR: ${{ github.workspace }}/pantry
     steps:
       - name: co pantry
         uses: actions/checkout@v3
@@ -64,14 +66,20 @@ jobs:
             ;;
           esac
 
-      - run: /opt/tea.xyz/var/pantry/scripts/sort.ts ${{ inputs.projects }}
+          # noop for pantry.core but needed for pantry.extra etc.
+          cp -R \
+            /opt/tea.xyz/var/pantry/scripts \
+            /opt/tea.xyz/var/pantry/import-map.json \
+            cli/src \
+            pantry
+
+      - run: pantry/scripts/sort.ts ${{ inputs.projects }}
         id: sorted
 
       - run: cli/scripts/install.ts ${{ steps.sorted.outputs.pre-install }}
 
-      - run: cat /opt/tea.xyz/var/pantry/projects/zlib.net/package.yml
-
-      - run: /opt/tea.xyz/var/pantry/scripts/build.ts ${{ steps.sorted.outputs.pkgs }}
+      # running out of /opt because only pantry.core has these scripts
+      - run: pantry/scripts/build.ts ${{ steps.sorted.outputs.pkgs }}
         id: build
         env:
           # GITHUB_TOKEN doesn't have private access to teaxyz/cli.
@@ -114,18 +122,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          path: pantry
-
-      - uses: actions/checkout@v3
-        with:
-          path: tea.xyz/var/cli
+          path: cli
           repository: teaxyz/cli
-          token: ${{ secrets.TEMP_JACOBS_GITHUB_PAT }}
-
-      - run: |
-          apt-get update
-          apt-get --yes install libc-dev libstdc++-8-dev libgcc-8-dev
-        if: ${{ matrix.container != '' }}
 
       - uses: teaxyz/setup@v0
         id: tea
@@ -133,13 +131,21 @@ jobs:
           srcroot: tea.xyz/var/pantry
           prefix: ${{ github.workspace }}
 
+      - uses: actions/checkout@v3
+        with:
+          path: tea.xyz/var/pantry
+
+      - run: |
+          apt-get update
+          apt-get --yes install libc-dev libstdc++-8-dev libgcc-8-dev
+        if: ${{ matrix.container != '' }}
+
       - uses: actions/download-artifact@v3
         with:
           name: ${{ matrix.tag || matrix.os }}
 
       - run: tar xzf artifacts.tgz
 
-      # script comes from pantry.core, which _might_not_be_this_pantry_
       - run: tea.xyz/var/pantry/scripts/test.ts ${{ inputs.projects }}
 
   bottle:
@@ -160,19 +166,18 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          path: pantry
-
-      - uses: actions/checkout@v3
-        with:
-          path: tea.xyz/var/cli
+          path: cli
           repository: teaxyz/cli
-          token: ${{ secrets.TEMP_JACOBS_GITHUB_PAT }}
 
       - uses: teaxyz/setup@v0
         id: tea
         with:
           srcroot: tea.xyz/var/pantry
           prefix: ${{ github.workspace }}
+
+      - uses: actions/checkout@v3
+        with:
+          path: tea.xyz/var/pantry
 
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       srcs: ${{ steps.build.outputs.srcs }}
       pkgs: ${{ steps.sorted.outputs.pkgs }} ${{ steps.sorted.outputs.pre-install }}
     env:
-      TEA_DIR: ${{ github.workspace }}/pantry
+      TEA_PANTRY_PATH: ${{ github.workspace }}/pantry
     steps:
       - name: co pantry
         uses: actions/checkout@v3
@@ -43,11 +43,11 @@ jobs:
         with:
           path: cli
           repository: teaxyz/cli
-          token: ${{ secrets.TEMP_JACOBS_GITHUB_PAT }}
 
       - uses: teaxyz/setup@v0
         id: tea
         with:
+          # necessary because we currently require a `.git` directory
           srcroot: /opt/tea.xyz/var/pantry
           prefix: /opt
 
@@ -66,20 +66,13 @@ jobs:
             ;;
           esac
 
-        - run: | # noop for pantry.core but needed for pantry.extra etc.
-            cp -nR \
-              /opt/tea.xyz/var/pantry/scripts \
-              /opt/tea.xyz/var/pantry/import-map.json \
-              pantry
-        - run: cd pantry && ln -sf ../cli/src
-
-      - run: pantry/scripts/sort.ts ${{ inputs.projects }}
+      - run: /opt/tea.xyz/var/pantry/scripts/sort.ts ${{ inputs.projects }}
         id: sorted
 
       - run: cli/scripts/install.ts ${{ steps.sorted.outputs.pre-install }}
 
       # running out of /opt because only pantry.core has these scripts
-      - run: pantry/scripts/build.ts ${{ steps.sorted.outputs.pkgs }}
+      - run: /opt/tea.xyz/var/scripts/build.ts ${{ steps.sorted.outputs.pkgs }}
         id: build
         env:
           # GITHUB_TOKEN doesn't have private access to teaxyz/cli.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
             /opt/tea.xyz/var/pantry/scripts \
             /opt/tea.xyz/var/pantry/import-map.json \
             pantry
-          ln -sf cli/src pantry/src
+          cd pantry && ln -sf ../cli/src
 
       - run: pantry/scripts/sort.ts ${{ inputs.projects }}
         id: sorted

--- a/README.md
+++ b/README.md
@@ -16,30 +16,38 @@ At this time pantries are not versioned.
 
 # Contributing
 
-Firstly, clone this repository, you’ll edit files here.
+Firstly, clone this repository, you’ll edit files here. *Don’t work out of
+`~/.tea/tea.xyz/var/pantry`*, it’s not a git directory!*
+
+You also must (currently, we know it sucks) clone tea/cli to the same *parent*
+directory. So you’ll have:
+
+```sh
+$ ls
+cli
+pantry.core
+```
+
+Keep tea/cli updated, currently there is unversioned revlock between the two.
+Also you should update your installed tea/cli frequently!)†
+
+> † `sh <(curl tea.xyz)` updates the installed tea/cli
 
 > Note that packages are split across multiple pantries, so to see the
 > `package.yml` files for all your dependencies you may want to open another
 > editor at `~/.tea/tea.xyz/var/pantry`
 
 Create new `package.yml` files namespaced as per our current patterns under
-the [`./projects/`] folder.
+the [`./projects/`] folder. The `package.yml` format is not documented
+(sorry!), but it is not complex, pick an existing entry for tips.
 
-The `package.yml` format is not documented, but it is not complex, pick an
-existing entry for tips.
-
-You should verify that your package builds before submitting it. At this time
-we require that we build all packages ourselves†. `tea` requires that
-packages are built to `/opt` to minimize potential build problems. You do not
-need to install `tea` to opt first, but you may need to make `/opt` writable
-first (`sudo chmod g+w /opt`).
+You should verify that your package builds before submitting it.
 
 ```sh
 export GITHUB_TOKEN=…   # you need a (zero permissions) [PAT]
-export TEA_PREFIX=/opt
-export TEA_PANTRY_PATH="$PWD"
 ./scripts/build.ts pkg.com
 # ^^ you will need to have installed all dependencies *manually* first
+# try `scripts/deps.ts -b pkg.com | xargs ../cli/scripts/install.ts`
 ```
 
 Packages require a `test` YAML node. This script should thoroughly verify all
@@ -50,14 +58,13 @@ the functionality of the package is working. You can run the test with:
 ```
 
 tea requires all packages be relocatable. Our CI will verify this for you.
-You can check locally by moving the installation from `/opt` to `~/.tea` and
-running the test again.
-
-> † we intend to relax this and accept pre-built binaries from third parties
-> however we will require third party verification for security reasons.
+You can check locally by moving the installation from `~/.tea` to another tea
+installation (eg. `~/.tea.build`‡ and running the test again.
 
 Now make a pull request! We’ll test on all platforms we support in the PR. If
-it passes both CI and review we’ll merge.
+it passes both CI and review: we’ll merge!
+
+> ‡ `TEA_PREFIX=~/.tea.build sh <(curl tea.xyz)`
 
 ## Packaging Guide
 

--- a/scripts/bottle.ts
+++ b/scripts/bottle.ts
@@ -14,6 +14,8 @@ args:
   - --allow-read
   - --allow-write
   - --import-map={{ srcroot }}/import-map.json
+env:
+  TEA_PANTRY_PATH: "{{srcroot}}"
 --- */
 
 import { Installation } from "types"

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -14,6 +14,8 @@ args:
   - --allow-write={{tea.prefix}}
   - --allow-env
   - --import-map={{ srcroot }}/import-map.json
+env:
+  TEA_PANTRY_PATH: "{{srcroot}}"
 ---*/
 
 import { usePantry } from "hooks"
@@ -21,7 +23,6 @@ import { Installation } from "types"
 import { pkg as pkgutils } from "utils"
 import { useFlags, usePrefix } from "hooks"
 import { set_output } from "./utils/gha.ts"
-import { overlay_this_pantry } from "./utils/misc.ts"
 import build, { BuildResult } from "./build/build.ts"
 import * as ARGV from "./utils/args.ts"
 import Path from "path"
@@ -33,13 +34,6 @@ const dry = await ARGV.toArray(ARGV.pkgs())
 const gha = !!Deno.env.get("GITHUB_ACTIONS")
 const group_it = gha && dry.length > 1
 const rv: BuildResult[] = []
-
-if (usePrefix().string != "/opt") {
-  console.error({ TEA_PREFIX: usePrefix().string })
-  throw new Error("builds must be performed in /opt (try TEA_PREFIX=/opt)")
-}
-
-await overlay_this_pantry()
 
 for (const rq of dry) {
   const pkg = await pantry.resolve(rq)

--- a/scripts/deps.ts
+++ b/scripts/deps.ts
@@ -7,6 +7,8 @@ args:
   - --allow-read
   - --allow-env
   - --import-map={{ srcroot }}/import-map.json
+env:
+  TEA_PANTRY_PATH: "{{srcroot}}"
 ---*/
 
 import { PackageRequirement } from "types"

--- a/scripts/fetch.ts
+++ b/scripts/fetch.ts
@@ -10,6 +10,8 @@ args:
   - --allow-write={{ tea.prefix }}
   - --allow-env
   - --import-map={{ srcroot }}/import-map.json
+env:
+  TEA_PANTRY_PATH: "{{srcroot}}"
 ---*/
 
 //TODO verify the sha

--- a/scripts/ls.ts
+++ b/scripts/ls.ts
@@ -14,6 +14,7 @@ args:
 import Path from "path"
 import { useFlags, usePrefix } from "hooks"
 
+//FIXME needs to get actual paths from usePantry
 const prefix = new Path(`${usePrefix()}/tea.xyz/var/pantry/projects`)
 
 interface Entry {

--- a/scripts/sort.ts
+++ b/scripts/sort.ts
@@ -7,6 +7,8 @@ args:
   - --allow-read
   - --allow-env
   - --import-map={{ srcroot }}/import-map.json
+env:
+  TEA_PANTRY_PATH: "{{srcroot}}"
 ---*/
 
 // sorts input for building

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -11,6 +11,8 @@ args:
   - --allow-env
   - --unstable
   - --import-map={{ srcroot }}/import-map.json
+env:
+  TEA_PANTRY_PATH: "{{srcroot}}"
 ---*/
 
 import { Installation, Package, PackageRequirement } from "types"
@@ -18,12 +20,10 @@ import { usePantry, useFlags, usePrefix } from "hooks"
 import useShellEnv, { expand } from "hooks/useShellEnv.ts"
 import { run, undent, pkg as pkgutils } from "utils"
 import { resolve, install, hydrate, link } from "prefab"
-import { overlay_this_pantry } from "./utils/misc.ts"
 import * as ARGV from "./utils/args.ts"
 import Path from "path"
 
 useFlags()
-
 const pantry = usePantry()
 
 for await (const pkg of ARGV.installs()) {
@@ -31,8 +31,6 @@ for await (const pkg of ARGV.installs()) {
 }
 
 async function test(self: Installation) {
-  await overlay_this_pantry()
-
   const yml = await pantry.getYAML(self.pkg).parse()
   const deps = await deps4(self.pkg)
   const installations = await prepare(deps)

--- a/scripts/utils/misc.ts
+++ b/scripts/utils/misc.ts
@@ -1,17 +1,5 @@
-import { usePrefix } from "hooks"
-
-export async function overlay_this_pantry() {
-  const pantry_prefix = usePrefix().join("tea.xyz/var/pantry")
+export function overlay_this_pantry() {
   const self = new URL(import.meta.url).path().parent().parent().parent().join("projects")
 
-  // noop, but also THIS FUCKS SHIT UP
-  if (self.parent().eq(pantry_prefix)) return
-
-  const to = pantry_prefix.join("projects")
-  for await (const [path, {isFile}] of self.walk()) {
-    if (isFile) {
-      const dst = to.join(path.relative({ to: self }))
-      path.cp({ into: dst.parent().mkpath() })
-    }
-  }
+  Deno.env.set("TEA_PANTRY_PATH", self.string)
 }

--- a/scripts/utils/misc.ts
+++ b/scripts/utils/misc.ts
@@ -1,5 +1,9 @@
 export function overlay_this_pantry() {
   const self = new URL(import.meta.url).path().parent().parent().parent().join("projects")
 
-  Deno.env.set("TEA_PANTRY_PATH", self.string)
+  // if unset just assume the user wants this
+  // this is magic in a bad way, but for now is what we're doing
+  if (!!Deno.env.get("TEA_PANTRY_PATH")) {
+    Deno.env.set("TEA_PANTRY_PATH", self.string)
+  }
 }


### PR DESCRIPTION
Improve README somewhat. Don’t overlay files into pantry, use `TEA_PANTRY_PATH` instead. Requires tea/cli 0.11.6 for `env` key in YAML-FM