### PR TITLE
add `interprets:` key to appropriate packages

### DIFF
--- a/projects/deno.land/package.yml
+++ b/projects/deno.land/package.yml
@@ -9,10 +9,8 @@ provides:
   - bin/deno
 
 interprets:
-  ts:
-    - deno
-    - run
-  # js: deno # nodejs.org for now
+  ts: [deno, run]
+  # js: [deno, run] # nodejs.org for now
 
 build:
   script: |

--- a/projects/deno.land/package.yml
+++ b/projects/deno.land/package.yml
@@ -9,8 +9,10 @@ provides:
   - bin/deno
 
 interprets:
-  - .ts
-  - .js
+  ts:
+    - deno
+    - run
+  # js: deno # nodejs.org for now
 
 build:
   script: |

--- a/projects/deno.land/package.yml
+++ b/projects/deno.land/package.yml
@@ -9,8 +9,9 @@ provides:
   - bin/deno
 
 interprets:
-  ts: [deno, run]
-  # js: [deno, run] # nodejs.org for now
+  # extensions: [ts, js] # nodejs.org for now
+  extensions: ts
+  args: [deno, run]
 
 build:
   script: |

--- a/projects/go.dev/package.yml
+++ b/projects/go.dev/package.yml
@@ -10,7 +10,9 @@ provides:
   - bin/go
 
 interprets:
-  - .go
+  go:
+    - go
+    - run
 
 dependencies:
   # `cgo` requires a C compiler

--- a/projects/go.dev/package.yml
+++ b/projects/go.dev/package.yml
@@ -27,6 +27,9 @@ build:
     go.dev: '*'
   working-directory: src
   script: |-
+    # `make.bash` complains about unset GOCACHE and HOME otherwise
+    export GOCACHE="$(pwd)/.gocache"
+
     ./make.bash
 
     # cleanup

--- a/projects/go.dev/package.yml
+++ b/projects/go.dev/package.yml
@@ -10,7 +10,8 @@ provides:
   - bin/go
 
 interprets:
-  go: [go, run]
+  extensions: go
+  args: [go, run]
 
 dependencies:
   # `cgo` requires a C compiler

--- a/projects/go.dev/package.yml
+++ b/projects/go.dev/package.yml
@@ -10,9 +10,7 @@ provides:
   - bin/go
 
 interprets:
-  go:
-    - go
-    - run
+  go: [go, run]
 
 dependencies:
   # `cgo` requires a C compiler

--- a/projects/nodejs.org/package.yml
+++ b/projects/nodejs.org/package.yml
@@ -17,7 +17,7 @@ provides:
   - bin/node
 
 interprets:
-  js: node
+  js: [node]
 
 build:
   dependencies:

--- a/projects/nodejs.org/package.yml
+++ b/projects/nodejs.org/package.yml
@@ -16,6 +16,9 @@ dependencies:
 provides:
   - bin/node
 
+interprets:
+  js: node
+
 build:
   dependencies:
     tea.xyz/gx/cc: c99

--- a/projects/nodejs.org/package.yml
+++ b/projects/nodejs.org/package.yml
@@ -17,7 +17,8 @@ provides:
   - bin/node
 
 interprets:
-  js: [node]
+  extensions: js
+  args: node
 
 build:
   dependencies:

--- a/projects/perl.org/package.yml
+++ b/projects/perl.org/package.yml
@@ -81,4 +81,5 @@ provides:
   - bin/zipdetails
 
 interprets:
-  pl: [perl]
+  extensions: pl
+  args: perl

--- a/projects/perl.org/package.yml
+++ b/projects/perl.org/package.yml
@@ -81,4 +81,4 @@ provides:
   - bin/zipdetails
 
 interprets:
-  pl: perl
+  pl: [perl]

--- a/projects/perl.org/package.yml
+++ b/projects/perl.org/package.yml
@@ -79,3 +79,6 @@ provides:
   - bin/streamzip
   - bin/xsubpp
   - bin/zipdetails
+
+interprets:
+  pl: perl

--- a/projects/python.org/package.yml
+++ b/projects/python.org/package.yml
@@ -12,6 +12,9 @@ provides:
   - bin/python
   - bin/python3  #FIXME this is only true of python 3
 
+interprets:
+  py: python
+
 dependencies:
 # recommended (but none are actually required)
   zlib.net: 1

--- a/projects/python.org/package.yml
+++ b/projects/python.org/package.yml
@@ -13,7 +13,7 @@ provides:
   - bin/python3  #FIXME this is only true of python 3
 
 interprets:
-  py: python
+  py: [python]
 
 dependencies:
 # recommended (but none are actually required)

--- a/projects/python.org/package.yml
+++ b/projects/python.org/package.yml
@@ -13,7 +13,8 @@ provides:
   - bin/python3  #FIXME this is only true of python 3
 
 interprets:
-  py: [python]
+  extensions: py
+  args: python
 
 dependencies:
 # recommended (but none are actually required)

--- a/projects/ruby-lang.org/package.yml
+++ b/projects/ruby-lang.org/package.yml
@@ -53,7 +53,7 @@ provides:
   - bin/ruby
 
 interprets:
-  rb: ruby
+  rb: [ruby]
 
 companions:
   rubygems.org: '*'

--- a/projects/ruby-lang.org/package.yml
+++ b/projects/ruby-lang.org/package.yml
@@ -53,7 +53,7 @@ provides:
   - bin/ruby
 
 interprets:
-  rb: ruby-lang.org
+  rb: ruby
 
 companions:
   rubygems.org: '*'

--- a/projects/ruby-lang.org/package.yml
+++ b/projects/ruby-lang.org/package.yml
@@ -52,5 +52,8 @@ provides:
   - bin/ri
   - bin/ruby
 
+interprets:
+  rb: ruby-lang.org
+
 companions:
   rubygems.org: '*'

--- a/projects/ruby-lang.org/package.yml
+++ b/projects/ruby-lang.org/package.yml
@@ -53,7 +53,8 @@ provides:
   - bin/ruby
 
 interprets:
-  rb: [ruby]
+  extensions: rb
+  args: ruby
 
 companions:
   rubygems.org: '*'


### PR DESCRIPTION
Adds `ts`, `js`, `pl`, `py`, `rb`, `go` interpreter keys to their respective packages.