### PR TITLE
npmjs.com: upstream removed ./scripts/install

### DIFF
--- a/projects/npmjs.com/package.yml
+++ b/projects/npmjs.com/package.yml
@@ -13,14 +13,10 @@ dependencies:
   nodejs.org: '>=14'
 
 build:
-  dependencies:
-    curl.se: '*'
-  script: |
-    ./scripts/install.sh
-  env:
-    npm_config_prefix: ${{prefix}}
+  script:
+    node . install --global --prefix={{prefix}}
 
 test:
   script: |
-    npm -g bin
+    npm -g doctor
     npx -q tldr ls

--- a/projects/npmjs.com/package.yml
+++ b/projects/npmjs.com/package.yml
@@ -17,6 +17,8 @@ build:
     node . install --global --prefix={{prefix}}
 
 test:
+  dependencies:
+    git-scm.org: '*' # `npm doctor` checks for, but doesn't use, `git`
   script: |
-    npm -g doctor
+    npm doctor
     npx -q tldr ls


### PR DESCRIPTION
which we shouldn't have been using anyway, since it was bypassing our downloaded sources. this is the correct way.
