### PR TITLE
chore: reorder and refactor scripts/upload.ts

### DIFF
--- a/scripts/upload.ts
+++ b/scripts/upload.ts
@@ -10,47 +10,47 @@ args:
   - --import-map={{ srcroot }}/import-map.json
 ---*/
 
-import { S3, S3Bucket } from "s3";
-import { pkg as pkgutils } from "utils";
-import { useCache, useFlags, useOffLicense, usePrefix } from "hooks";
-import { Package, PackageRequirement } from "types";
-import SemVer, * as semver from "semver";
-import { basename, dirname } from "deno/path/mod.ts";
-import Path from "path";
-import { set_output } from "./utils/gha.ts";
-import { sha256 } from "./bottle.ts";
+import { S3, S3Bucket } from "s3"
+import { pkg as pkgutils } from "utils"
+import { useCache, useFlags, useOffLicense, usePrefix } from "hooks"
+import { Package, PackageRequirement } from "types"
+import SemVer, * as semver from "semver"
+import { basename, dirname } from "deno/path/mod.ts"
+import Path from "path"
+import { set_output } from "./utils/gha.ts"
+import { sha256 } from "./bottle.ts"
 
 //------------------------------------------------------------------------- funcs
 function args_get(key: string): string[] {
-  const it = Deno.args[Symbol.iterator]();
+  const it = Deno.args[Symbol.iterator]()
   while (true) {
-    const { value, done } = it.next();
-    if (done) throw new Error();
-    if (value === `--${key}`) break;
+    const { value, done } = it.next()
+    if (done) throw new Error()
+    if (value === `--${key}`) break
   }
-  const rv: string[] = [];
+  const rv: string[] = []
   while (true) {
-    const { value, done } = it.next();
-    if (done) return rv;
-    if (value.startsWith("--")) return rv;
-    rv.push(value);
+    const { value, done } = it.next()
+    if (done) return rv
+    if (value.startsWith("--")) return rv
+    rv.push(value)
   }
 }
 
 function assert_pkg(pkg: Package | PackageRequirement) {
   if ("version" in pkg) {
-    return pkg;
+    return pkg
   } else {
     return {
       project: pkg.project,
       version: new SemVer(pkg.constraint),
-    };
+    }
   }
 }
 
 async function get_versions(key: string, pkg: Package, bucket: S3Bucket): Promise<SemVer[]> {
-  const prefix = dirname(key);
-  const rsp = await bucket.listObjects({ prefix });
+  const prefix = dirname(key)
+  const rsp = await bucket.listObjects({ prefix })
 
   //FIXME? API isn’t clear if these nulls indicate failure or not
   //NOTE if this is a new package then some empty results is expected
@@ -60,76 +60,76 @@ async function get_versions(key: string, pkg: Package, bucket: S3Bucket): Promis
     .map((x) => basename(x))
     .filter((x) => x.match(/v.*\.tar\.gz$/))
     .map((x) => x.replace(/v(.*)\.tar\.gz/, "$1")) ??
-    [];
+    []
 
   // have to add pkg.version as put and get are not atomic
   return [...new Set([...got, pkg.version.toString()])]
     .compact(semver.parse)
-    .sort(semver.compare);
+    .sort(semver.compare)
 }
 
 async function put(key: string, body: string | Path | Uint8Array, bucket: S3Bucket) {
-  console.log({ uploading: body, to: key });
-  rv.push(`/${key}`);
+  console.log({ uploading: body, to: key })
+  rv.push(`/${key}`)
   if (body instanceof Path) {
-    body = await Deno.readFile(body.string);
+    body = await Deno.readFile(body.string)
   } else if (typeof body === "string") {
-    body = encode(body);
+    body = encode(body)
   }
-  return bucket.putObject(key, body);
+  return bucket.putObject(key, body)
 }
 
 //------------------------------------------------------------------------- main
-useFlags();
+useFlags()
 
-if (Deno.args.length === 0) throw new Error("no args supplied");
+if (Deno.args.length === 0) throw new Error("no args supplied")
 
 const s3 = new S3({
   accessKeyID: Deno.env.get("AWS_ACCESS_KEY_ID")!,
   secretKey: Deno.env.get("AWS_SECRET_ACCESS_KEY")!,
   region: "us-east-1",
-});
+})
 
-const bucket = s3.getBucket(Deno.env.get("AWS_S3_BUCKET")!);
+const bucket = s3.getBucket(Deno.env.get("AWS_S3_BUCKET")!)
 const encode = (() => {
-  const e = new TextEncoder();
-  return e.encode.bind(e);
-})();
-const cache = useCache();
+  const e = new TextEncoder()
+  return e.encode.bind(e)
+})()
+const cache = useCache()
 
-const pkgs = args_get("pkgs").map(pkgutils.parse).map(assert_pkg);
-const srcs = args_get("srcs");
-const bottles = args_get("bottles");
-const checksums = args_get("checksums");
+const pkgs = args_get("pkgs").map(pkgutils.parse).map(assert_pkg)
+const srcs = args_get("srcs")
+const bottles = args_get("bottles")
+const checksums = args_get("checksums")
 
-const rv: string[] = [];
+const rv: string[] = []
 
 for (const [index, pkg] of pkgs.entries()) {
-  const bottle = new Path(bottles[index]);
-  const checksum = checksums[index];
-  const stowed = cache.decode(bottle)!;
-  const key = useOffLicense("s3").key(stowed);
-  const versions = await get_versions(key, pkg, bucket);
+  const bottle = new Path(bottles[index])
+  const checksum = checksums[index]
+  const stowed = cache.decode(bottle)!
+  const key = useOffLicense("s3").key(stowed)
+  const versions = await get_versions(key, pkg, bucket)
 
   //FIXME stream the bottle (at least) to S3
-  await put(key, bottle, bucket);
-  await put(`${key}.sha256sum`, `${checksum}  ${basename(key)}`, bucket);
-  await put(`${dirname(key)}/versions.txt`, versions.join("\n"), bucket);
+  await put(key, bottle, bucket)
+  await put(`${key}.sha256sum`, `${checksum}  ${basename(key)}`, bucket)
+  await put(`${dirname(key)}/versions.txt`, versions.join("\n"), bucket)
 
   // mirror the sources
   if (srcs[index] != "~") {
-    const src = usePrefix().join(srcs[index]);
+    const src = usePrefix().join(srcs[index])
     const srcKey = useOffLicense("s3").key({
       pkg: stowed.pkg,
       type: "src",
       extname: src.extname(),
-    });
-    const srcChecksum = await sha256(src);
-    const srcVersions = await get_versions(srcKey, pkg, bucket);
-    await put(srcKey, src, bucket);
-    await put(`${srcKey}.sha256sum`, `${srcChecksum}  ${basename(srcKey)}`, bucket);
-    await put(`${dirname(srcKey)}/versions.txt`, srcVersions.join("\n"), bucket);
+    })
+    const srcChecksum = await sha256(src)
+    const srcVersions = await get_versions(srcKey, pkg, bucket)
+    await put(srcKey, src, bucket)
+    await put(`${srcKey}.sha256sum`, `${srcChecksum}  ${basename(srcKey)}`, bucket)
+    await put(`${dirname(srcKey)}/versions.txt`, srcVersions.join("\n"), bucket)
   }
 }
 
-await set_output("cf-invalidation-paths", rv);
+await set_output("cf-invalidation-paths", rv)

--- a/scripts/upload.ts
+++ b/scripts/upload.ts
@@ -10,123 +10,126 @@ args:
   - --import-map={{ srcroot }}/import-map.json
 ---*/
 
-import { S3 } from "s3"
-import { pkg as pkgutils } from "utils"
-import { useFlags, useOffLicense, useCache, usePrefix } from "hooks"
-import { Package, PackageRequirement } from "types"
-import SemVer, * as semver from "semver"
-import { dirname, basename } from "deno/path/mod.ts"
-import Path from "path"
-import { set_output } from "./utils/gha.ts"
-import { sha256 } from "./bottle.ts"
+import { S3 } from "s3";
+import { pkg as pkgutils } from "utils";
+import { useCache, useFlags, useOffLicense, usePrefix } from "hooks";
+import { Package, PackageRequirement } from "types";
+import SemVer, * as semver from "semver";
+import { basename, dirname } from "deno/path/mod.ts";
+import Path from "path";
+import { set_output } from "./utils/gha.ts";
+import { sha256 } from "./bottle.ts";
 
-useFlags()
-
-if (Deno.args.length === 0) throw new Error("no args supplied")
-
-const s3 = new S3({
-  accessKeyID: Deno.env.get("AWS_ACCESS_KEY_ID")!,
-  secretKey: Deno.env.get("AWS_SECRET_ACCESS_KEY")!,
-  region: "us-east-1",
-})
-
-const bucket = s3.getBucket(Deno.env.get("AWS_S3_BUCKET")!)
-const encode = (() => { const e = new TextEncoder(); return e.encode.bind(e) })()
-const cache = useCache()
-
-const pkgs = args_get("pkgs").map(pkgutils.parse).map(assert_pkg)
-const srcs = args_get("srcs")
-const bottles = args_get("bottles")
-const checksums = args_get("checksums")
-
-
+//------------------------------------------------------------------------- funcs
 function args_get(key: string): string[] {
-  const it = Deno.args[Symbol.iterator]()
+  const it = Deno.args[Symbol.iterator]();
   while (true) {
-    const { value, done } = it.next()
-    if (done) throw new Error()
-    if (value === `--${key}`) break
+    const { value, done } = it.next();
+    if (done) throw new Error();
+    if (value === `--${key}`) break;
   }
-  const rv: string[] = []
+  const rv: string[] = [];
   while (true) {
-    const { value, done } = it.next()
-    if (done) return rv
-    if (value.startsWith('--')) return rv
-    rv.push(value)
+    const { value, done } = it.next();
+    if (done) return rv;
+    if (value.startsWith("--")) return rv;
+    rv.push(value);
   }
 }
 
-const rv: string[] = []
-const put = async (key: string, body: string | Path | Uint8Array) => {
-  console.log({ uploading: body, to: key })
-  rv.push(`/${key}`)
-  if (body instanceof Path) {
-    body = await Deno.readFile(body.string)
-  } else if (typeof body === "string") {
-    body = encode(body)
-  }
-  return bucket.putObject(key, body)
-}
-
-for (const [index, pkg] of pkgs.entries()) {
-  const bottle = new Path(bottles[index])
-  const checksum = checksums[index]
-  const stowed = cache.decode(bottle)!
-  const key = useOffLicense('s3').key(stowed)
-  const versions = await get_versions(key, pkg)
-
-  //FIXME stream the bottle (at least) to S3
-  await put(key, bottle)
-  await put(`${key}.sha256sum`, `${checksum}  ${basename(key)}`)
-  await put(`${dirname(key)}/versions.txt`, versions.join("\n"))
-
-  // mirror the sources
-  if (srcs[index] != "~") {
-    const src = usePrefix().join(srcs[index])
-    const srcKey = useOffLicense('s3').key({
-      pkg: stowed.pkg,
-      type: "src",
-      extname: src.extname()
-    })
-    const srcChecksum = await sha256(src)
-    const srcVersions = await get_versions(srcKey, pkg)
-    await put(srcKey, src)
-    await put(`${srcKey}.sha256sum`, `${srcChecksum}  ${basename(srcKey)}`)
-    await put(`${dirname(srcKey)}/versions.txt`, srcVersions.join("\n"))
+function assert_pkg(pkg: Package | PackageRequirement) {
+  if ("version" in pkg) {
+    return pkg;
+  } else {
+    return {
+      project: pkg.project,
+      version: new SemVer(pkg.constraint),
+    };
   }
 }
-
-await set_output('cf-invalidation-paths', rv)
-
-//end
 
 async function get_versions(key: string, pkg: Package): Promise<SemVer[]> {
-  const prefix = dirname(key)
-  const rsp = await bucket.listObjects({ prefix })
+  const prefix = dirname(key);
+  const rsp = await bucket.listObjects({ prefix });
 
   //FIXME? API isn’t clear if these nulls indicate failure or not
   //NOTE if this is a new package then some empty results is expected
   const got = rsp
     ?.contents
-    ?.compact(x => x.key)
-    .map(x => basename(x))
-    .filter(x => x.match(/v.*\.tar\.gz$/))
-    .map(x => x.replace(/v(.*)\.tar\.gz/, "$1"))
-    ?? []
+    ?.compact((x) => x.key)
+    .map((x) => basename(x))
+    .filter((x) => x.match(/v.*\.tar\.gz$/))
+    .map((x) => x.replace(/v(.*)\.tar\.gz/, "$1")) ??
+    [];
 
   // have to add pkg.version as put and get are not atomic
   return [...new Set([...got, pkg.version.toString()])]
     .compact(semver.parse)
-    .sort(semver.compare)
+    .sort(semver.compare);
 }
 
-function assert_pkg(pkg: Package | PackageRequirement) {
-  if ("version" in pkg) {
-    return pkg
-  } else {
-    return {
-      project: pkg.project,
-      version: new SemVer(pkg.constraint)
-    }
+async function put(key: string, body: string | Path | Uint8Array) {
+  console.log({ uploading: body, to: key });
+  rv.push(`/${key}`);
+  if (body instanceof Path) {
+    body = await Deno.readFile(body.string);
+  } else if (typeof body === "string") {
+    body = encode(body);
+  }
+  return bucket.putObject(key, body);
+}
+
+//------------------------------------------------------------------------- main
+useFlags();
+
+if (Deno.args.length === 0) throw new Error("no args supplied");
+
+const s3 = new S3({
+  accessKeyID: Deno.env.get("AWS_ACCESS_KEY_ID")!,
+  secretKey: Deno.env.get("AWS_SECRET_ACCESS_KEY")!,
+  region: "us-east-1",
+});
+
+const bucket = s3.getBucket(Deno.env.get("AWS_S3_BUCKET")!);
+const encode = (() => {
+  const e = new TextEncoder();
+  return e.encode.bind(e);
+})();
+const cache = useCache();
+
+const pkgs = args_get("pkgs").map(pkgutils.parse).map(assert_pkg);
+const srcs = args_get("srcs");
+const bottles = args_get("bottles");
+const checksums = args_get("checksums");
+
+const rv: string[] = [];
+
+for (const [index, pkg] of pkgs.entries()) {
+  const bottle = new Path(bottles[index]);
+  const checksum = checksums[index];
+  const stowed = cache.decode(bottle)!;
+  const key = useOffLicense("s3").key(stowed);
+  const versions = await get_versions(key, pkg);
+
+  //FIXME stream the bottle (at least) to S3
+  await put(key, bottle);
+  await put(`${key}.sha256sum`, `${checksum}  ${basename(key)}`);
+  await put(`${dirname(key)}/versions.txt`, versions.join("\n"));
+
+  // mirror the sources
+  if (srcs[index] != "~") {
+    const src = usePrefix().join(srcs[index]);
+    const srcKey = useOffLicense("s3").key({
+      pkg: stowed.pkg,
+      type: "src",
+      extname: src.extname(),
+    });
+    const srcChecksum = await sha256(src);
+    const srcVersions = await get_versions(srcKey, pkg);
+    await put(srcKey, src);
+    await put(`${srcKey}.sha256sum`, `${srcChecksum}  ${basename(srcKey)}`);
+    await put(`${dirname(srcKey)}/versions.txt`, srcVersions.join("\n"));
   }
 }
+
+await set_output("cf-invalidation-paths", rv);


### PR DESCRIPTION
- reorder code to separate _functions_ and _main_ in 2 sections (e.g., as in [ls.ts](https://github.com/teaxyz/pantry.core/blob/05c0d227146b9e99a4f63ee40839e1b537925bc0/scripts/ls.ts#L26))
- format code to uniform style
- add `bucket` as a parameter to the `get_version` and  `put ` functions to avoid the use of global variables

This is related to https://github.com/teaxyz/pantry.core/issues/32