### PR TITLE
scripts: await useShellEnv

### DIFF
--- a/scripts/build/build.ts
+++ b/scripts/build/build.ts
@@ -29,7 +29,7 @@ export default async function _build(pkg: Package): Promise<BuildResult> {
 async function __build(pkg: Package): Promise<BuildResult> {
   const [deps, wet, resolved] = await calc_deps()
   await clean()
-  const env = mkenv()
+  const env = await mkenv()
   const dst = cellar.keg(pkg).mkpath()
   const [src, src_tarball] = await fetch_src(pkg) ?? []
   const installation = await build()
@@ -71,8 +71,8 @@ async function __build(pkg: Package): Promise<BuildResult> {
     }
   }
 
-  function mkenv() {
-    const env = useShellEnv({ installations: resolved})
+  async function mkenv() {
+    const env = await useShellEnv({ installations: resolved})
 
     if (platform == 'darwin') {
       env['MACOSX_DEPLOYMENT_TARGET'] = ['11.0']

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -37,7 +37,7 @@ async function test(self: Installation) {
   // get linked when they're tested.
   await link(self)
 
-  const env = useShellEnv({ installations: [self, ...installations] })
+  const env = await useShellEnv({ installations: [self, ...installations] })
 
   let text = undent`
     #!/bin/bash


### PR DESCRIPTION
Updated APIs in https://github.com/teaxyz/cli/pull/207.

Is there a better way to deal with these cross-repo breaking changes?