### PR TITLE
llvm.org@15

### DIFF
--- a/projects/freedesktop.org/pkg-config/package.yml
+++ b/projects/freedesktop.org/pkg-config/package.yml
@@ -1,5 +1,5 @@
 distributable:
-  url: https://pkgconfig.freedesktop.org/releases/pkg-config-{{ version }}.tar.gz
+  url: https://pkgconfig.freedesktop.org/releases/pkg-config-{{version}}.tar.gz
   strip-components: 1
 
 provides:

--- a/projects/freedesktop.org/pkg-config/package.yml
+++ b/projects/freedesktop.org/pkg-config/package.yml
@@ -31,6 +31,8 @@ build:
       - --with-internal-glib
       # otherwise the defaults are based on our {{prefix}}
       - --with-pc-path=/usr/lib/pkgconfig:/usr/share/pkgconfig
+    # llvm15 changed this to hard error
+    CFLAGS: -Wno-error=int-conversion
 
 test:
   script: pkg-config --version

--- a/projects/llvm.org/package.yml
+++ b/projects/llvm.org/package.yml
@@ -5,9 +5,6 @@ distributable:
 versions:
   github: llvm/llvm-project
   strip: /^LLVM /
-  ignore: 15.0.0
-  # ^^ won’t even build pkg-config lol
-  # tested: [15.0.0]
 
 provides:
   - bin/lld

--- a/projects/llvm.org/package.yml
+++ b/projects/llvm.org/package.yml
@@ -5,7 +5,7 @@ distributable:
 versions:
   github: llvm/llvm-project
   strip: /^LLVM /
-  ignore: 15.y.z
+  ignore: 15.0.0
   # ^^ won’t even build pkg-config lol
   # tested: [15.0.0]
 


### PR DESCRIPTION
Change in llvm@15 breaks pkg-config build (and possibly others, since I found that at Gnome's gitlab): https://gitlab.gnome.org/GNOME/gimp/-/issues/8649.

I'm not sure I like this solution, but it's a bug in pkg-config not llvm, really....

