### PR TITLE
llvm^15 doesn't agree with several of our packages

### DIFF
--- a/projects/rust-lang.org/package.yml
+++ b/projects/rust-lang.org/package.yml
@@ -31,6 +31,8 @@ options:
 dependencies:
   tea.xyz/gx/cc: c99
   #FIXME ^^ strictly rustc only needs a linker
+  linux:
+    llvm.org: '>=12<15' # doesn't seem to play nicely with llvm15 yet.
   zlib.net: 1
 
 build:

--- a/projects/rust-lang.org/package.yml
+++ b/projects/rust-lang.org/package.yml
@@ -31,8 +31,6 @@ options:
 dependencies:
   tea.xyz/gx/cc: c99
   #FIXME ^^ strictly rustc only needs a linker
-  linux:
-    llvm.org: '>=12<15' # doesn't seem to play nicely with llvm15 yet.
   zlib.net: 1
 
 build:

--- a/projects/tea.xyz/gx/cc/package.yml
+++ b/projects/tea.xyz/gx/cc/package.yml
@@ -7,7 +7,9 @@ versions:
 
 dependencies:
   linux:
-    llvm.org: '*'
+    llvm.org: '<15'   # Right now, at least 8 packages don't build with llvm^15 in the environment.
+                      # There shouldn't be any particular harm with limiting this for now. But, it
+                      # should definitely be FIXME.
   darwin:
     apple.com/xcode/clt: '*'
 


### PR DESCRIPTION
Right now, a number of packages don't like when tea.xyz/gx/cc brings in llvm.org^15. Since darwin is using clang-14, I think we're reasonably safe to do this for now (though a smaller range might be wiser).

Proof of concept:

Before: https://github.com/teaxyz/pantry.core/actions/runs/3682963301

After: https://github.com/teaxyz/pantry.core/actions/runs/3717714454