### PR TITLE
Just use the full build.ts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,13 +73,8 @@ jobs:
       - run: /opt/tea.xyz/var/pantry/scripts/sort.ts ${{ inputs.projects }}
         id: sorted
 
-      - run: /opt/tea.xyz/var/pantry/scripts/build-deps.ts ${{ steps.sorted.outputs.pkgs }}
-        id: deps
-
-      - run: cli/scripts/install.ts ${{ steps.deps.outputs.pkgs }}
-
       # running out of /opt because only pantry.core has these scripts
-      - run: /opt/tea.xyz/var/pantry/scripts/build.plumbing.ts ${{ steps.sorted.outputs.pkgs }}
+      - run: /opt/tea.xyz/var/pantry/scripts/build.ts ${{ steps.sorted.outputs.pkgs }}
         id: build
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/scripts/build.plumbing.ts
+++ b/scripts/build.plumbing.ts
@@ -14,13 +14,11 @@ args:
 ---*/
 
 import { usePantry } from "hooks"
-import { Installation } from "types"
 import { pkg as pkgutils } from "utils"
 import { useFlags, usePrefix } from "hooks"
 import { set_output } from "./utils/gha.ts"
 import build, { BuildResult } from "./build/build.ts"
 import * as ARGV from "./utils/args.ts"
-import Path from "path"
 
 useFlags()
 
@@ -52,7 +50,3 @@ await set_output("paths", rv.map(x => x.installation.path), '%0A')
 await set_output("relative-paths", rv.map(x => x.installation.path.relative({ to })))
 await set_output("srcs", rv.map(x => x.src?.relative({ to }) ?? "~"))
 await set_output("srcs-relative-paths", rv.compact(x => x.src?.relative({ to })))
-
-interface InstallationPlus extends Installation {
-  src: Path
-}


### PR DESCRIPTION
Fixes issue where we don't install zlib to build zlib even though llvm needs it.

Doing these in steps was a cool demo of our primitives but led to issues due to install all deps up front rather than just before each build so fuck it.