### PR TITLE
fix deno.land=1.29.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,11 +18,10 @@ jobs:
         platform:
           - os: macos-11
             name: darwin+x86-64
-          - os: ubuntu-latest
+          - os: ubuntu-latest-4-cores
             name: linux+x86-64
             container:
               image: debian:buster-slim
-              options: --memory=24g
           - os: [self-hosted, macOS, ARM64]
             name: darwin+aarch64
           - os: [self-hosted, linux, ARM64]


### PR DESCRIPTION
we just need bigger builders for some rusty stuff. pay-per-minute, but we'll see how much it hurts. should speed up linux builds in any case.