### PR TITLE
invisible-island.net/ncurses: add legacy symlinks

### DIFF
--- a/projects/invisible-island.net/ncurses/package.yml
+++ b/projects/invisible-island.net/ncurses/package.yml
@@ -15,6 +15,15 @@ build:
     mkdir -p $PCDIR
     ./configure $ARGS
     make --jobs {{ hw.concurrency }} install
+
+    # fix up symlinks
+    cd {{prefix}}/lib
+    for lib in form menu ncurses panel curses++; do
+      for ii in $(find . -name lib${lib}w\*); do
+        # hopefully no new w's will be introduced
+        ln -s $ii $(echo $ii | tr -d w)
+      done
+    done
   env:
     PCDIR: ${{prefix}}/lib/pkgconfig
     ARGS:


### PR DESCRIPTION
For https://github.com/teaxyz/pantry.extra/pull/110#issuecomment-1377243210. Untested on Linux but I think this should work with the different shared library names.