### PR TITLE
add `build.cores` yaml key to control min-required build machine

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,14 +11,34 @@ env:
   TEA_PANTRY_PATH: ${{ github.workspace }}/pantry
 
 jobs:
+  check-core-sizes:
+    runs-on: ubuntu-latest
+    outputs:
+      gha-linux-build-size: ${{ env.GHA_LINUX_BUILD_SIZE }}
+    steps:
+      - name: co pantry
+        uses: actions/checkout@v3
+        with:
+          path: pantry
+          repository: teaxyz/pantry.core
+
+      - uses: teaxyz/setup@v0
+        with:
+          # necessary because we currently require a `.git` directory
+          srcroot: ~/pantry
+
+      - run: ./scripts/check-core-sizes.ts ${{ inputs.projects }}
+        working-directory: pantry
+
   build:
     runs-on: ${{ matrix.platform.os }}
+    needs: [check-core-sizes]
     strategy:
       matrix:
         platform:
           - os: macos-11
             name: darwin+x86-64
-          - os: ubuntu-latest-4-cores
+          - os: ${{ needs.check-core-sizes.outputs.gha-linux-build-size }}
             name: linux+x86-64
             container:
               image: debian:buster-slim

--- a/projects/deno.land/package.yml
+++ b/projects/deno.land/package.yml
@@ -18,6 +18,7 @@ runtime:
     DENO_NO_UPDATE_CHECK: "true"
 
 build:
+  cores: 4
   script: |
     # https://github.com/denoland/deno/issues/15596 -- reported fixed in 1.25.3
     if test {{ version.major }} -eq 1 -a {{ version.minor }} -eq 25 -a {{ version.patch }} -lt 3; then

--- a/scripts/check-core-sizes.ts
+++ b/scripts/check-core-sizes.ts
@@ -1,0 +1,51 @@
+#!/usr/bin/env -S tea -E
+
+/*---
+args:
+  - deno
+  - run
+  - --allow-read
+  - --allow-env
+  - --allow-write
+  - --import-map={{ srcroot }}/import-map.json
+---*/
+
+import { usePantry } from "hooks"
+import * as ARGV from "./utils/args.ts"
+
+const pantry = usePantry()
+
+const pkgs = await ARGV.toArray(ARGV.pkgs())
+
+let coreSize = 2
+
+for (const pkg of pkgs) {
+  const yml = await pantry.getYAML(pkg).parse()
+  if (yml?.build?.cores) {
+    coreSize = Math.max(yml.build.cores, coreSize)
+  }
+}
+
+const output = `GHA_LINUX_BUILD_SIZE=${imageName(coreSize)}\n`
+
+Deno.stdout.write(new TextEncoder().encode(output))
+
+if (Deno.env.get("GITHUB_ENV")) {
+  const envFile = Deno.env.get("GITHUB_ENV")!
+  await Deno.writeTextFile(envFile, output, { append: true})
+}
+
+function imageName(size: number) {
+  switch (size) {
+    case 0:
+    case 1:
+    case 2:
+      return "ubuntu-latest"
+    case 4:
+    case 8:
+    case 16:
+      return `ubuntu-latest-${size}-cores`
+    default:
+      throw new Error("Invalid core size")
+  }
+}


### PR DESCRIPTION
Adds `build.cores` key to `package.yml` to allow specific packages to use the larger linux build environments as required. Deno is the only (known?) package to require up-building today. IIRC.