### PR TITLE
two-digit versions need a `v`

### DIFF
--- a/projects/darwinsys.com/file/package.yml
+++ b/projects/darwinsys.com/file/package.yml
@@ -4,7 +4,7 @@ distributable:
   strip-components: 1
 
 versions:
-  - 5.43
+  - v5.43
   #TODO github: file/file/tags (has an awful format :/)
 
 dependencies:

--- a/projects/freedesktop.org/shared-mime-info/package.yml
+++ b/projects/freedesktop.org/shared-mime-info/package.yml
@@ -3,7 +3,7 @@ distributable:
   strip-components: 1
 
 versions:
-  - 2.2
+  - v2.2
 
 dependencies:
   gnome.org/glib: 2

--- a/projects/gnu.org/coreutils/package.yml
+++ b/projects/gnu.org/coreutils/package.yml
@@ -3,7 +3,7 @@ distributable:
   strip-components: 1
 
 versions:
-  - 9.1
+  - v9.1
 
 provides:
 - bin/[

--- a/projects/gnu.org/make/package.yml
+++ b/projects/gnu.org/make/package.yml
@@ -4,7 +4,7 @@ distributable:
 
 versions:
   # github: mirror/make/tags -- these versions don't match the source versions...
-  - 4.3
+  - v4.3
 
 provides:
   - bin/make

--- a/projects/gnu.org/readline/package.yml
+++ b/projects/gnu.org/readline/package.yml
@@ -4,7 +4,7 @@ distributable:
 
 versions:
   #TODO brew has a couple patches we should apply
-  - 8.1
+  - v8.1
 
 dependencies:
   invisible-island.net/ncurses: 6

--- a/projects/gnu.org/tar/package.yml
+++ b/projects/gnu.org/tar/package.yml
@@ -3,7 +3,7 @@ distributable:
   strip-components: 1
 
 versions:
-  - 1.34
+  - v1.34
   #TODO scrape https://ftp.gnu.org/gnu/tar/
 
 provides:

--- a/projects/info-zip.org/unzip/package.yml
+++ b/projects/info-zip.org/unzip/package.yml
@@ -8,7 +8,7 @@ distributable:
   strip-components: 1
 
 versions:
-  - '6.0'
+  - v6.0
 
 #TODO
 # see brew formula, they apply a SHIT TONNE of patches

--- a/projects/pcre.org/package.yml
+++ b/projects/pcre.org/package.yml
@@ -9,7 +9,7 @@ distributable:
 # despite PCRE being unmaintained, most stuff still uses it, lol
 
 versions:
-  - 8.45
+  - v8.45
 
 dependencies:
   sourceware.org/bzip2: 1


### PR DESCRIPTION
@mxcl, do you like this fix for https://github.com/teaxyz/cli/blob/3e66ef99ea1fe9db92f8035a716544e4bd26c581/src/utils/semver.ts#L24-L29 or do you think we should revert that trap in semver.ts.

If we like this, I'll prep a similar one for pantry.extra.

resolves https://github.com/orgs/teaxyz/discussions/295