### PR TITLE
fix git libexec rpaths

### DIFF
--- a/projects/git-scm.org/config.mak
+++ b/projects/git-scm.org/config.mak
@@ -2,4 +2,4 @@ RUNTIME_PREFIX = YesPlease
 RUNTIME_PREFIX_PERL = YesPlease
 
 # must be set or the above are still abs paths
-gitexecdir=libexec/git-core
+gitexecdir=libexec

--- a/projects/git-scm.org/package.yml
+++ b/projects/git-scm.org/package.yml
@@ -48,8 +48,8 @@ test: |
   test "$(git diff --name-only --cached)" = "testfile"
 
   # necessary so `git commit` will work
-  git config --global user.email "you@example.com"
-  git config --global user.name "Your Name"
+  git config user.email "you@example.com"
+  git config user.name "Your Name"
 
   # necessary to check the libexec binaries work
   git commit --message "test"

--- a/projects/git-scm.org/package.yml
+++ b/projects/git-scm.org/package.yml
@@ -47,6 +47,10 @@ test: |
   git add .
   test "$(git diff --name-only --cached)" = "testfile"
 
+  # necessary so `git commit` will work
+  git config --global user.email "you@example.com"
+  git config --global user.name "Your Name"
+
   # necessary to check the libexec binaries work
   git commit --message "test"
 

--- a/projects/git-scm.org/package.yml
+++ b/projects/git-scm.org/package.yml
@@ -22,9 +22,9 @@ build:
     make install $BAKE
 
     cd "{{prefix}}"
-    DEBUG=1 fix-shebangs.ts bin/* libexec/git-core/*
+    DEBUG=1 fix-shebangs.ts bin/* libexec/*
 
-    mkdir etc
+    mkdir -p etc
     cp "$SRCROOT"/props/git* etc
   env:
     V: 1
@@ -46,6 +46,9 @@ test: |
   git init
   git add .
   test "$(git diff --name-only --cached)" = "testfile"
+
+  # necessary to check the libexec binaries work
+  git commit --message "test"
 
 provides:
   - bin/git


### PR DESCRIPTION
The fix works by having the relative path component count be the same between bin and libexec