### PR TITLE
git needs libexpat

### DIFF
--- a/projects/git-scm.org/package.yml
+++ b/projects/git-scm.org/package.yml
@@ -10,6 +10,7 @@ dependencies:
   gnu.org/gettext: ^0.21
   curl.se: '>=5'
   perl.org: '*'
+  libexpat.github.io: ~2
 
 runtime:
   env:


### PR DESCRIPTION
Passing tests (guessing those envs provide like mac does):

```sh
docker run -it debian
root@9ce00b79bc73:/# apt-get update; apt-get -y install curl
...
root@9ce00b79bc73:/# TEA_YES=1 sh <(curl tea.xyz)
...
root@9ce00b79bc73:/# tea git clone https://github.com/teaxyz/cli
Cloning into 'cli'...
/root/.tea/git-scm.org/v2.39.0/libexec/git-remote-https: error while loading shared libraries: libexpat.so.1: cannot open shared object file: No such file or directory
root@9ce00b79bc73:/# ldd ~/.tea/git-scm.org/v2.39.0/libexec/git-remote-https
...
	libexpat.so.1 => not found
```
and
```sh
otool -l ~/.tea/git-scm.org/v2/libexec/git-core/git-remote-https  | grep -C2 libexpat
          cmd LC_LOAD_DYLIB
      cmdsize 56
         name /usr/lib/libexpat.1.dylib (offset 24)
   time stamp 2 Wed Dec 31 19:00:02 1969
      current version 8.0.0
```