### PR TITLE
+ca-certs

### DIFF
--- a/projects/curl.se/ca-certs/package.yml
+++ b/projects/curl.se/ca-certs/package.yml
@@ -1,0 +1,22 @@
+distributable: ~
+
+versions:
+  - 2022.07.19
+
+runtime:
+  env:
+    SSL_CERT_FILE: ${{prefix}}/ssl/cert.pem
+
+build:
+  dependencies:
+    curl.se: '*'
+  script: |
+    cd "{{prefix}}"
+    mkdir -p ssl
+    URL_VER=$(echo {{version.raw}} | tr -- . -)
+    curl -k https://curl.se/ca/cacert-$URL_VER.pem -o ssl/cert.pem
+
+test:
+  dependencies:
+    curl.se: '*'
+  script: curl https://tea.xyz

--- a/projects/openssl.org/package.yml
+++ b/projects/openssl.org/package.yml
@@ -17,12 +17,14 @@ provides:
   - bin/openssl
   - bin/c_rehash
 
+dependencies:
+  curl.se/ca-certs: '*'
+
 build:
   dependencies:
     tea.xyz/gx/cc: c99
     tea.xyz/gx/make: '*'
     perl.org: 5
-    curl.se: '*'    # to download ca-certs on linux
     git-scm.org: 2  # to apply our patch
   script: |
     git apply props/x509_def.c.diff
@@ -31,12 +33,6 @@ build:
     make --jobs {{ hw.concurrency }}
     make install_sw   # `_sw` avoids installing docs
 
-    #FIXME needs to be a curl.se/ca-certs that gets updates
-    #FIXME on macOS use /etc/ssl/cert.pem (I couldn't make this work)
-    #FIXME or on macOS get certs from the keychain
-    cd "{{prefix}}"
-    mkdir -p ssl
-    curl -k https://curl.se/ca/cacert-2022-07-19.pem -o ssl/cert.pem
   env:
     darwin/aarch64: {ARCH: 'darwin64-arm64-cc'}
     darwin/x86-64:  {ARCH: 'darwin64-x86_64-cc'}


### PR DESCRIPTION
I think this handles it. Included in [the Top 300](https://github.com/teaxyz/pantry.extra/issues/99). Some other recipes can be pruned back to just using the cert files, but that'll require testing. Goes with https://github.com/teaxyz/cli/pull/322.

NB: `new-version` was run against this branch on https://github.com/teaxyz/pantry.core/commit/45f856554bf70317907c128e87ec6475e784c8a6 in order to get bottles of `curl.se/ca-certs` so the bootstrap could be unwound. *IF* this PR gets rejected, those bottles should be unpublished.