### PR TITLE
Prevent fork bombing from `cc` -> `tea` symlinks

### DIFF
--- a/projects/tea.xyz/gx/cc/cc.rb
+++ b/projects/tea.xyz/gx/cc/cc.rb
@@ -22,6 +22,9 @@ exe_path = ENV['PATH'].split(":").filter { |path|
   path != File.dirname(__FILE__)
 }.map { |path|
   "#{path}/#{exe}"
+}.reject { |path|
+  # if the user created a symlink of `cc` to `tea` don’t use it
+  File.symlink? path and File.basename(File.readlink(path)) == "tea"
 }.find { |path|
   File.exist?(path)
 }

--- a/projects/tea.xyz/gx/cc/package.yml
+++ b/projects/tea.xyz/gx/cc/package.yml
@@ -1,9 +1,9 @@
 distributable: ~
 
-# FIXME we want the c version eg. c99 
+# FIXME we want the c version eg. c99
 # or should that be some kind of option? so you specify you want a cc that support c99
 versions:
-  - 0.1.2
+  - 0.1.3
 
 dependencies:
   linux:


### PR DESCRIPTION
note that we have fork bomb protection in tea/cli itself so this didn't fork bomb to fruition.

Fixes https://github.com/teaxyz/cli/issues/306