### PR TITLE
fix newer deno.land builds

### DIFF
--- a/projects/deno.land/package.yml
+++ b/projects/deno.land/package.yml
@@ -30,6 +30,10 @@ build:
       fi
     fi
 
+    # FIXME: until we unblock rust-lang.org>1.65.0, we need a feature flag
+    # to compile deno.land
+    git apply props/unzip_option_feature.diff
+
     cargo build --release
     mkdir -p "{{ prefix }}"/bin
     mv target/release/deno "{{ prefix }}"/bin

--- a/projects/deno.land/unzip_option_feature.diff
+++ b/projects/deno.land/unzip_option_feature.diff
@@ -1,0 +1,13 @@
+diff -ru a/cli/main.rs b/cli/main.rs
+--- a/cli/main.rs	2023-01-26 19:14:19
++++ b/cli/main.rs	2023-01-26 19:15:00
+@@ -1,5 +1,9 @@
+ // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+ 
++// tea::FIXME
++// remove this once rust-lang.org>1.65.0 is unblocked
++#![feature(unzip_option)]
++
+ mod args;
+ mod auth_tokens;
+ mod cache;


### PR DESCRIPTION
Since deno always uses the newest stable rust, it's using a feature that just went stable, but our compile still has it gated behind a feature flag. So we add that in, until our rust catches up.

resolves #131