### PR TITLE
fix(ruby)

### DIFF
--- a/projects/ruby-lang.org/package.yml
+++ b/projects/ruby-lang.org/package.yml
@@ -3,7 +3,7 @@ distributable:
   strip-components: 1
 
 versions:
-  github: ruby/ruby/tags
+  github: ruby/ruby
 
 dependencies:
   openssl.org: ^1.1


### PR DESCRIPTION
Tags are underscore delimited; they all resolve to =3.0.0
