### PR TITLE
scripts/fetch.ts: explicit dependency on deno

### DIFF
--- a/scripts/fetch.ts
+++ b/scripts/fetch.ts
@@ -5,6 +5,7 @@ dependencies:
   gnu.org/tar: 1
   tukaani.org/xz: 5
   sourceware.org/bzip2: 1
+  deno.land: '*'
 args:
   - deno
   - run


### PR DESCRIPTION
Hitting an issue on local (non-Docker) builds with `__tea_splitter`:

```console
% teab bun.sh   
fetching bun.sh=0.5.6
tea: command not found: [
  "deno",
  "run",
  "--allow-net",
  "--allow-run",
  "--allow-read",
  "--allow-write=/Users/jonchang/.tea",
  "--allow-env",
  "/Users/jonchang/tea/pantry.core/scripts/fetch.ts",
  "bun.sh=0.5.6"
]
error: Uncaught (in promise) Error
  if (!status.success) throw new Error()
                             ^
    at fetch_src (file:///Users/jonchang/tea/pantry.core/scripts/build/build.ts:160:30)
    at async __build (file:///Users/jonchang/tea/pantry.core/scripts/build/build.ts:33:30)
    at async _build (file:///Users/jonchang/tea/pantry.core/scripts/build/build.ts:21:12)
    at async file:///Users/jonchang/tea/pantry.core/scripts/build.ts:45:11

```