### PR TITLE
fix(go)

### DIFF
--- a/projects/go.dev/package.yml
+++ b/projects/go.dev/package.yml
@@ -37,7 +37,11 @@ build:
     cd ..
     rm src/*.{bash,bat,rc}
     rm src/Make.dist
-    rm -rf "{{prefix}}"/*
+    if test -d "{{prefix}}"; then
+      find "{{prefix}}" -mindepth 1 -delete
+    else
+      mkdir "{{prefix}}"
+    fi
     mv * "{{prefix}}"
     find "{{prefix}}" -mindepth 1 -maxdepth 1 -type f -delete -not -name build.sh
   env:


### PR DESCRIPTION
fix empty prefix globs causing the build script to fail