### PR TITLE
better clean artifact unpacking during tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,7 +119,7 @@ jobs:
         # Note: needed when changing a directory to a symlink, for example in
         # https://github.com/teaxyz/pantry.extra/pull/435
         run: |
-          tar tzf artifacts.tgz | \
+          tar tzf $GITHUB_WORKSPACE/artifacts.tgz | \
             awk '{ print length, $0 }' | \
             sort -n -s -r | \
             cut -d" " -f2- | \


### PR DESCRIPTION
this fixes the extremely rare case where a package is installed during cache setup, then a never version is unpacked over it with changes that tar cannot easily handle (see: https://github.com/teaxyz/pantry.extra/pull/435 changing a directory to a symlink).

This could have been done simply in GNU tar with `--unlink-recursive --unlink-first` but BSD tar (darwin) doesn't support `--unlink-recursive`.