### PR TITLE
use PIC/PIE on linux-x86-64

### DIFF
--- a/projects/tea.xyz/gx/cc/package.yml
+++ b/projects/tea.xyz/gx/cc/package.yml
@@ -13,6 +13,13 @@ dependencies:
   darwin:
     apple.com/xcode/clt: '*'
 
+runtime:
+  env:
+    linux/x86-64:
+      LDFLAGS: $LDFLAGS -pie
+      CFLAGS: $CFLAGS -fPIC
+      CXXFLAGS: $CXXFLAGS -fPIC
+
 build:
   working-directory:
     ${{prefix}}/bin


### PR DESCRIPTION
Ubuntu turns on PIC/PIE by default (since 16.04). ChatGPT thinks this might be the fix. I can affirm that it helps a number of segfault issues for different packages.

Testing, you know, needed.

PR/Issuess where this fix was the correct fix:
- [x] https://github.com/teaxyz/pantry.extra/pull/453
- [x] https://github.com/teaxyz/pantry.core/pull/318
- [x] https://github.com/teaxyz/pantry.core/issues/458
- [x] https://github.com/teaxyz/pantry.extra/pull/455
- [x] https://github.com/teaxyz/pantry.extra/pull/456
- [x] https://github.com/teaxyz/pantry.core/pull/466
- [x] https://github.com/teaxyz/pantry.extra/pull/421
- [x] https://github.com/teaxyz/pantry.extra/pull/432