### PR TITLE
Don’t set TEA_PREFIX

### DIFF
--- a/.github/actions/setup-brewkit/action.yml
+++ b/.github/actions/setup-brewkit/action.yml
@@ -24,7 +24,7 @@ runs:
       id: tea
       with:
         prefix: ${{ inputs.prefix }}
-        +: tea.xyz/brewkit~0.5
+        +: tea.xyz/brewkit~0.7
         # prevent pantry from reassigning TEA_PREFIX etc.
         srcroot: null
 
@@ -33,7 +33,7 @@ runs:
         cache-name: setup
 
     - run: |
-        if test -d "{{ github.workspace }}"/projects; then
+        if test -d "${{ github.workspace }}"/projects; then
           echo "TEA_PANTRY_PATH=${{ github.workspace }}" >> $GITHUB_ENV
         fi
       shell: sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           FORCE_UNSAFE_CONFIGURE: 1  # some configure scripts refuse to run as root
-          TEA_PANTRY_PATH: ${{ github.workspace }}
 
       - run: |
           ABS_PATHS=$(echo $PATHS | tr ' ' '\n' | sed -e "s_^_$TEA_PREFIX/_" | tr '\n' ' ')
@@ -132,7 +131,6 @@ jobs:
       - run: pkg test ${{ inputs.projects }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          TEA_PANTRY_PATH: ${{ github.workspace }}
 
       - name: '[post]'
         run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,6 @@ jobs:
     needs: [get-diff]
     uses: ./.github/workflows/build.yml
     with:
-      projects: ${{ needs.get-diff.outputs.diff || 'zlib.net' }}
+      projects: ${{ needs.get-diff.outputs.diff || 'zlib.net=1.2.7.2' }}
       platform: ${{ matrix.platform }}
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,6 @@ jobs:
     needs: [get-diff]
     uses: ./.github/workflows/build.yml
     with:
-      projects: ${{ needs.get-diff.outputs.diff || 'zlib.net=1.2.7.2' }}
+      projects: ${{ needs.get-diff.outputs.diff || 'zlib.net^1.2' }}
       platform: ${{ matrix.platform }}
     secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-/tea.out
-/tea.linux
+/srcs
+/builds
+/testbeds
 
 #TODO commit after v1
 /deno.lock

--- a/README.md
+++ b/README.md
@@ -24,21 +24,24 @@ Assuming you have tea+magic installed:
 $ git clone https://github.com/teaxyz/pantry.core
 
 $ cd pantry.core
-# all the following commands operate in `./tea.out`
-# your tea installation remains untouched
 
 $ pkg init
 # ^^ creates a “wip” package.yml
 
 $ pkg edit
-# ^^ opens the new package.yml in your EDITOR
+# ^^ opens the new package.yml in your `$EDITOR`
 
 $ pkg build
-# ^^ will probably require a (zero permissions) GitHub [PAT].
-# Using `gh auth login` is the easiest way to set this up.
+# ^^ runs the build script from your package.yml
+# refer to other packages for examples
+# ^^ usually requires a (zero permissions) GitHub [PAT]
+# either set `$GITHUB_TOKEN` or run `gh auth login` (once) first
+# builds in `./srcs`, installs to `~/.tea`
 
 $ pkg test
-# ^^ you need to write a test that verifies the package works
+# ^^ runs the test script from your package.yml
+# refer to other packages for examples
+# ^^ operates in `./tests`
 
 $ gh repo fork
 $ git branch -m my-new-package
@@ -46,10 +49,11 @@ $ git push origin my-new-package
 $ gh pr create
 ```
 
-> `pkg` can be run without magic via `tea -E pkg` (this dev-env provides `+tea.xyz/brewkit`).
-> `gh` can be run without magic via `tea gh`.
-> `git` can be run without magic via `tea git`.
-
+> * `pkg` can be run without magic via `tea -E pkg` (this dev-env provides `+tea.xyz/brewkit`).
+> * `gh` can be run without magic via `tea gh`.
+> * `git` can be run without magic via `tea git`.
+> * `pkg build` and `pkg test` take a `-L` flag to run in a Linux Docker container
+> * All commands take an optional pkg-spec eg. `pkg build zlib.net^1.1`
 
 ## Packaging Guide
 

--- a/tea.yaml
+++ b/tea.yaml
@@ -1,5 +1,4 @@
 dependencies:
-  tea.xyz/brewkit: ~0.5
+  tea.xyz/brewkit: ~0.7
 env:
-  TEA_PANTRY_PATH: ${{srcroot}}:{{home}}/.tea/tea.xyz/var/pantry
-  TEA_PREFIX: ${{srcroot}}/tea.out
+  TEA_PANTRY_PATH: ${{srcroot}}


### PR DESCRIPTION
Fixes https://github.com/teaxyz/cli/issues/427

We build to TEA_PREFIX by default in pantry dev-envs now. You can still override this if you want.

`TEA_PANTRY_PATH=foo tea bar` will now use